### PR TITLE
Added "wizard" helpers  `complete` and `disabled`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Copy to your vendor directory and link up the .js file.
   {{#ivy-tab-list}}
     {{#ivy-tab}}Foo{{/ivy-tab}}
     {{#ivy-tab}}Bar{{/ivy-tab}}
-    {{#ivy-tab}}Baz{{/ivy-tab}}
+    {{#ivy-tab isDisabled=disabledAttr}}Baz{{/ivy-tab}}
   {{/ivy-tab-list}}
 
   {{#ivy-tab-panel}}

--- a/addon/components/ivy-tab-list.js
+++ b/addon/components/ivy-tab-list.js
@@ -145,7 +145,13 @@ export default Ember.Component.extend({
    * @param {Number} index
    */
   selectTabByIndex: function(index) {
+    var tabs = this.get('tabs');
+
     this.set('selected-index', index);
+
+    for (var i = tabs.length - 1; i >= 0; i--) {
+      tabs[i].set('isComplete', i < index);
+    }
   },
 
   /**

--- a/addon/components/ivy-tab-list.js
+++ b/addon/components/ivy-tab-list.js
@@ -95,9 +95,11 @@ export default Ember.Component.extend({
    * @method selectNextTab
    */
   selectNextTab: function() {
-    var index = this.get('selected-index') + 1;
-    if (index === this.get('tabs.length')) { index = 0; }
-    this.selectTabByIndex(index);
+    var nextTab = this.findNextEnabledTab( this.get('selected-index') );
+
+    if (nextTab) {
+      this.selectTab( nextTab );
+    }
   },
 
   /**
@@ -106,14 +108,75 @@ export default Ember.Component.extend({
    * @method selectPreviousTab
    */
   selectPreviousTab: function() {
-    var index = this.get('selected-index') - 1;
+    var prevTab = this.findPreviousEnabledTab( this.get('selected-index') );
 
-    // Previous from the first tab should select the last tab.
-    if (index < 0) { index = this.get('tabs.length') - 1; }
-    // This would only happen if there are no tabs, so stay at 0.
-    if (index < 0) { index = 0; }
+    if (prevTab) {
+      this.selectTab( prevTab );
+    }
+  },
 
-    this.selectTabByIndex(index);
+  /**
+   * Finds next tab that is not disabled
+   *
+   * @method findNextEnabledTab
+   * @param {String} index
+   */
+  findNextEnabledTab: function findNextEnabledTab(index) {
+    var lastIndex = this.get('tabs.length') - 1,
+        tabs = this.get('tabs'),
+        i, tab;
+
+    index++;
+
+    for (i = index; i <= lastIndex; i++) {
+      tab = tabs.objectAt(i);
+
+      if (!tab.get('isDisabled')) {
+        return tab;
+      }
+    }
+
+    for (i = 0; i < index; i++) {
+      tab = tabs.objectAt(i);
+
+      if (!tab.get('isDisabled')) {
+        return tab;
+      }
+    }
+
+    return null;
+  },
+
+  /**
+   * Finds previous tab that is not disabled
+   *
+   * @method findPreviousEnabledTab
+   * @param {String} index
+   */
+  findPreviousEnabledTab: function findPreviousEnabledTab(index) {
+    var lastIndex = this.get('tabs.length') - 1,
+        tabs = this.get('tabs'),
+        i, tab;
+
+    index--;
+
+    for (i = index; i >= 0; i--) {
+      tab = tabs.objectAt(i);
+
+      if (!tab.get('isDisabled')) {
+        return tab;
+      }
+    }
+
+    for (i = lastIndex; i > index; i--) {
+      tab = tabs.objectAt(i);
+
+      if (!tab.get('isDisabled')) {
+        return tab;
+      }
+    }
+
+    return null;
   },
 
   'selected-index': Ember.computed.alias('tabsContainer.selected-index'),
@@ -145,7 +208,12 @@ export default Ember.Component.extend({
    * @param {Number} index
    */
   selectTabByIndex: function(index) {
-    var tabs = this.get('tabs');
+    var tabs = this.get('tabs'),
+        tab = tabs.objectAt(index);
+
+    if (!tab || tab.get('isDisabled')) {
+      return;
+    }
 
     this.set('selected-index', index);
 

--- a/addon/components/ivy-tab.js
+++ b/addon/components/ivy-tab.js
@@ -13,7 +13,7 @@ export default Ember.Component.extend({
   tagName: 'li',
   attributeBindings: ['aria-controls', 'aria-expanded', 'aria-selected', 'role', 'selected', 'tabindex'],
   classNames: ['ivy-tab'],
-  classNameBindings: ['active'],
+  classNameBindings: ['active', 'complete'],
 
   init: function() {
     this._super();
@@ -114,6 +114,28 @@ export default Ember.Component.extend({
    * @default 'active'
    */
   activeClass: 'active',
+
+  /**
+   * Accessed as a className binding to apply the tab's `completeClass` CSS class
+   * to the element when the tab's `isComplete` property is true.
+   *
+   * @property complete
+   * @type String
+   * @readOnly
+   */
+  complete: Ember.computed(function() {
+    if (this.get('isComplete')) { return this.get('completeClass'); }
+  }).property('isComplete'),
+
+  /**
+   * The CSS class to apply to a tab's element when its `isComplete` property
+   * is `true`.
+   *
+   * @property completeClass
+   * @type String
+   * @default 'complete'
+   */
+  completeClass: 'complete',
 
   /**
    * The index of this tab in the `ivy-tab-list` component.

--- a/addon/components/ivy-tab.js
+++ b/addon/components/ivy-tab.js
@@ -11,7 +11,7 @@ import Ember from 'ember';
  */
 export default Ember.Component.extend({
   tagName: 'li',
-  attributeBindings: ['aria-controls', 'aria-expanded', 'aria-selected', 'role', 'selected', 'tabindex'],
+  attributeBindings: ['aria-controls', 'aria-expanded', 'aria-selected', 'aria-disabled', 'role', 'selected', 'disabled', 'tabindex'],
   classNames: ['ivy-tab'],
   classNameBindings: ['active', 'complete'],
 
@@ -60,6 +60,18 @@ export default Ember.Component.extend({
   }).property('isSelected'),
 
   /**
+   * Tells screenreaders whether or not this tab is disabled.
+   *
+   * See http://www.w3.org/TR/wai-aria/states_and_properties#aria-disabled
+   *
+   * @property aria-disabled
+   * @type String
+   */
+  'aria-disabled': Ember.computed(function() {
+    return this.get('isDisabled') + ''; // coerce to 'true' or 'false'
+  }).property('isDisabled'),
+
+  /**
    * The `role` attribute of the tab element.
    *
    * See http://www.w3.org/TR/wai-aria/roles#tab
@@ -81,6 +93,28 @@ export default Ember.Component.extend({
   selected: Ember.computed(function() {
     if (this.get('isSelected')) { return 'selected'; }
   }).property('isSelected'),
+
+  /**
+   * The `disabled` attribute of the tab element. If the tab's `isDisabled`
+   * property is `true` this will be the literal string 'disabled', otherwise
+   * it will be `undefined`.
+   *
+   * @property disabled
+   * @type String
+   */
+  disabled: Ember.computed(function() {
+    if (this.get('isDisabled')) { return 'disabled'; }
+  }).property('isDisabled'),
+
+  /**
+   * The CSS class to apply to a tab's element when its `isDisabled` property
+   * is `true`.
+   *
+   * @property isDisabled
+   * @type String
+   * @default false
+   */
+  isDisabled: false,
 
   /**
    * Makes the selected tab keyboard tabbable, and prevents tabs from getting

--- a/tests/unit/components/ivy-tabs-test.js
+++ b/tests/unit/components/ivy-tabs-test.js
@@ -10,6 +10,7 @@ var basicTemplate =
   '  {{#ivy-tab-list id="tablist"}}' +
   '    {{#ivy-tab id="tab1"}}tab 1{{/ivy-tab}}' +
   '    {{#ivy-tab id="tab2"}}tab 2{{/ivy-tab}}' +
+  '    {{#ivy-tab id="tab3" isDisabled=true}}tab 2{{/ivy-tab}}' +
   '  {{/ivy-tab-list}}' +
   '  {{#ivy-tab-panel id="panel1"}}panel 1{{/ivy-tab-panel}}' +
   '  {{#ivy-tab-panel id="panel2"}}panel 2{{/ivy-tab-panel}}' +
@@ -33,6 +34,13 @@ test('selects tab on click', function(assert) {
   this.$('#tab2').click();
 
   assert.equal(this.get('selectedIndex'), 1, 'selected-index');
+});
+
+test('does not select disabled tab on click', function(assert) {
+  this.render(basicTemplate);
+  this.$('#tab3').click();
+
+  assert.notEqual(this.get('selectedIndex'), 2, 'selected-index');
 });
 
 test('selects tab on touchEnd', function(assert) {


### PR DESCRIPTION
Now, you can easily disable a tab and bind it to an attribute:

```
{{#ivy-tabs}}
  {{#ivy-tab-list class="stepper"}}
    {{#ivy-tab isDisabled=disabledAttr}}
      Tab content
    {{/ivy-tab}}
  {{/ivy-tab-list}}
{{/ivy-tabs}}
```

Also added a `complete` class to previous tabs to help with styling when it comes to creating an onboarding wizard. The class can be customized as well:

```
{{#ivy-tabs}}
  {{#ivy-tab-list completeClass="step-is-complete"}}
    ...
  {{/ivy-tab-list}}
{{/ivy-tabs}}
```