### PR TITLE
Convert to contextual components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1-13
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ A group of Ember.js Components that interact to create a [WAI-ARIA tab] interfac
 
 Special thanks to [ic-tabs], which this addon is based on.
 
+**NOTE: This addon uses contextual components, which require Ember >= 2.3. For
+older versions of Ember, use the 1.x release series of this addon.**
+
 ## Installation
 
 ```sh
@@ -16,33 +19,30 @@ $ ember install ivy-tabs
 ## Usage
 
 ```handlebars
-{{#ivy-tabs as |tabsContainer|}}
-  {{#ivy-tab-list tabsContainer=tabsContainer as |tabList|}}
-    {{#ivy-tab tabList=tabList}}Foo{{/ivy-tab}}
-    {{#ivy-tab tabList=tabList}}Bar{{/ivy-tab}}
-    {{#ivy-tab tabList=tabList}}Baz{{/ivy-tab}}
-  {{/ivy-tab-list}}
+{{#ivy-tabs as |tabs|}}
+  {{#tabs.tablist as |tablist|}}
+    {{#tablist.tab}}Foo{{/tablist.tab}}
+    {{#tablist.tab}}Bar{{/tablist.tab}}
+    {{#tablist.tab}}Baz{{/tablist.tab}}
+  {{/tabs.tablist}}
 
-  {{#ivy-tab-panel tabsContainer=tabsContainer}}
+  {{#tabs.tabpanel}}
     <h2>Foo</h2>
-  {{/ivy-tab-panel}}
+  {{/tabs.tabpanel}}
 
-  {{#ivy-tab-panel tabsContainer=tabsContainer}}
+  {{#tabs.tabpanel}}
     <h2>Bar</h2>
-  {{/ivy-tab-panel}}
+  {{/tabs.tabpanel}}
 
-  {{#ivy-tab-panel tabsContainer=tabsContainer}}
+  {{#tabs.tabpanel}}
     <h2>Baz</h2>
-  {{/ivy-tab-panel}}
+  {{/tabs.tabpanel}}
 {{/ivy-tabs}}
 ```
 
 Some things to note:
 
   * Associations between tabs and tab-panes are inferred by order.
-  * Both `ivy-tabs` and `ivy-tab-list` yield themselves as a parameter, which
-    should be passed down to their children as `tabsContainer` and `tabList`,
-    respectively.
 
 ## Contributing
 

--- a/addon/templates/components/ivy-tab-list.hbs
+++ b/addon/templates/components/ivy-tab-list.hbs
@@ -1,1 +1,1 @@
-{{yield this}}
+{{yield (hash tab=(component "ivy-tab" tabList=this))}}

--- a/addon/templates/components/ivy-tabs.hbs
+++ b/addon/templates/components/ivy-tabs.hbs
@@ -1,1 +1,1 @@
-{{yield this}}
+{{yield (hash tablist=(component 'ivy-tab-list' tabsContainer=this) tabpanel=(component 'ivy-tab-panel' tabsContainer=this))}}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,17 +8,6 @@ module.exports = {
       }
     },
     {
-      name: 'ember-1-13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      }
-    },
-    {
       name: 'ember-release',
       bower: {
         dependencies: {

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,12 +1,12 @@
-{{#ivy-tabs as |tabsContainer|}}
-  {{#ivy-tab-list tabsContainer=tabsContainer as |tabList|}}
-    {{#ivy-tab tabList=tabList}}Tab A{{/ivy-tab}}
-    {{#ivy-tab tabList=tabList}}Tab B{{/ivy-tab}}
-    {{#ivy-tab tabList=tabList}}Tab C{{/ivy-tab}}
-  {{/ivy-tab-list}}
+{{#ivy-tabs as |tabs|}}
+  {{#tabs.tablist as |tablist|}}
+    {{#tablist.tab}}Tab A{{/tablist.tab}}
+    {{#tablist.tab}}Tab B{{/tablist.tab}}
+    {{#tablist.tab}}Tab C{{/tablist.tab}}
+  {{/tabs.tablist}}
 
   <div class="tab-content">
-    {{#ivy-tab-panel tabsContainer=tabsContainer}}
+    {{#tabs.tabpanel}}
       <h2>Tab A</h2>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
@@ -17,9 +17,9 @@
         occaecat cupidatat non proident, sunt in culpa qui officia deserunt
         mollit anim id est laborum.
       </p>
-    {{/ivy-tab-panel}}
+    {{/tabs.tabpanel}}
 
-    {{#ivy-tab-panel tabsContainer=tabsContainer}}
+    {{#tabs.tabpanel}}
       <h2>Tab B</h2>
       <p>
         Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -29,9 +29,9 @@
         occaecat cupidatat non proident, sunt in culpa qui officia deserunt
         mollit anim id est laborum.
       </p>
-    {{/ivy-tab-panel}}
+    {{/tabs.tabpanel}}
 
-    {{#ivy-tab-panel tabsContainer=tabsContainer}}
+    {{#tabs.tabpanel}}
       <h2>Tab C</h2>
       <p>
         Veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -41,6 +41,6 @@
         mollit anim id est laborum.
         Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim.
       </p>
-    {{/ivy-tab-panel}}
+    {{/tabs.tabpanel}}
   </div>
 {{/ivy-tabs}}

--- a/tests/integration/components/ivy-tabs-test.js
+++ b/tests/integration/components/ivy-tabs-test.js
@@ -7,13 +7,13 @@ moduleForComponent('ivy-tabs', {
 });
 
 const basicTemplate = hbs`
-  {{#ivy-tabs selected-index=selectedIndex as |tabsContainer|}}
-    {{#ivy-tab-list id="tablist" tabsContainer=tabsContainer as |tabList|}}
-      {{#ivy-tab id="tab1" tabList=tabList}}tab 1{{/ivy-tab}}
-      {{#ivy-tab id="tab2" tabList=tabList}}tab 2{{/ivy-tab}}
-    {{/ivy-tab-list}}
-    {{#ivy-tab-panel id="panel1" tabsContainer=tabsContainer}}panel 1{{/ivy-tab-panel}}
-    {{#ivy-tab-panel id="panel2" tabsContainer=tabsContainer}}panel 2{{/ivy-tab-panel}}
+  {{#ivy-tabs selected-index=selectedIndex as |tabs|}}
+    {{#tabs.tablist id="tablist" as |tablist|}}
+      {{#tablist.tab id="tab1"}}tab 1{{/tablist.tab}}
+      {{#tablist.tab id="tab2"}}tab 2{{/tablist.tab}}
+    {{/tabs.tablist}}
+    {{#tabs.tabpanel id="panel1"}}panel 1{{/tabs.tabpanel}}
+    {{#tabs.tabpanel id="panel2"}}panel 2{{/tabs.tabpanel}}
   {{/ivy-tabs}}
 `;
 
@@ -99,14 +99,14 @@ test('deselected panel attributes', function(assert) {
 });
 
 const eachTemplate = hbs`
-  {{#ivy-tabs selected-index=selectedIndex as |tabsContainer|}}
-    {{#ivy-tab-list tabsContainer=tabsContainer as |tabList|}}
+  {{#ivy-tabs selected-index=selectedIndex as |tabs|}}
+    {{#tabs.tablist as |tablist|}}
       {{#each items as |item|}}
-        {{#ivy-tab tabList=tabList}}{{item}}{{/ivy-tab}}
+        {{#tablist.tab}}{{item}}{{/tablist.tab}}
       {{/each}}
-    {{/ivy-tab-list}}
+    {{/tabs.tablist}}
     {{#each items as |item|}}
-      {{#ivy-tab-panel tabsContainer=tabsContainer}}{{item}}{{/ivy-tab-panel}}
+      {{#tabs.tabpanel}}{{item}}{{/tabs.tabpanel}}
     {{/each}}
   {{/ivy-tabs}}
 `;


### PR DESCRIPTION
This PR adds contextual component support, which changes the `ivy-tabs` invocation to:

```handlebars
{{#ivy-tabs as |tabs|}}
  {{#tabs.tablist as |tablist|}}
    {{#tablist.tab}}tab 1{{/tablist.tab}}
    {{#tablist.tab}}tab 2{{/tablist.tab}}
  {{/tabs.tablist}}
  {{#tabs.tabpanel}}panel 1{{/tabs.tabpanel}}
  {{#tabs.tabpanel}}panel 2{{/tabs.tabpanel}}
{{/ivy-tabs}}
```

Obviously, since contextual components are not supported in Ember versions prior to 2.3, this PR would drop support for those older versions.