### PR TITLE
Data down, Actions up

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ ember install ivy-tabs
 ## Usage
 
 ```handlebars
-{{#ivy-tabs selected-index=selectedIndex update=(action (mut selectedIndex)) as |tabs|}}
+{{#ivy-tabs on-select=(action (mut selectedIndex)) selected-index=selectedIndex as |tabs|}}
   {{#tabs.tablist as |tablist|}}
     {{#tablist.tab}}Foo{{/tablist.tab}}
     {{#tablist.tab}}Bar{{/tablist.tab}}
@@ -43,7 +43,7 @@ $ ember install ivy-tabs
 Some things to note:
 
   * Associations between tabs and panels are inferred by order.
-  * An `update` action is sent when a tab is selected. As an argument, it
+  * An `on-select` action is sent when a tab is selected. As an argument, it
     receives the index (0-based) of the selected tab.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ ember install ivy-tabs
 ## Usage
 
 ```handlebars
-{{#ivy-tabs as |tabs|}}
+{{#ivy-tabs selected-index=selectedIndex update=(action (mut selectedIndex)) as |tabs|}}
   {{#tabs.tablist as |tablist|}}
     {{#tablist.tab}}Foo{{/tablist.tab}}
     {{#tablist.tab}}Bar{{/tablist.tab}}
@@ -43,6 +43,8 @@ $ ember install ivy-tabs
 Some things to note:
 
   * Associations between tabs and panels are inferred by order.
+  * An `update` action is sent when a tab is selected. As an argument, it
+    receives the index (0-based) of the selected tab.
 
 ## Contributing
 

--- a/addon/components/ivy-tab-list.js
+++ b/addon/components/ivy-tab-list.js
@@ -148,7 +148,7 @@ export default Ember.Component.extend({
    * @param {Number} index
    */
   selectTabByIndex(index) {
-    this.sendAction('update', index);
+    this.sendAction('on-select', index);
   },
 
   tabs: Ember.computed(function() {

--- a/addon/components/ivy-tab-list.js
+++ b/addon/components/ivy-tab-list.js
@@ -148,7 +148,7 @@ export default Ember.Component.extend({
    * @param {Number} index
    */
   selectTabByIndex(index) {
-    this.set('selected-index', index);
+    this.sendAction('update', index);
   },
 
   tabs: Ember.computed(function() {

--- a/addon/templates/components/ivy-tabs.hbs
+++ b/addon/templates/components/ivy-tabs.hbs
@@ -1,1 +1,1 @@
-{{yield (hash tablist=(component "ivy-tab-list" tabsContainer=this) tabpanel=(component "ivy-tab-panel" tabsContainer=this))}}
+{{yield (hash tablist=(component "ivy-tab-list" tabsContainer=this update=update) tabpanel=(component "ivy-tab-panel" tabsContainer=this))}}

--- a/addon/templates/components/ivy-tabs.hbs
+++ b/addon/templates/components/ivy-tabs.hbs
@@ -1,1 +1,1 @@
-{{yield (hash tablist=(component "ivy-tab-list" tabsContainer=this update=update) tabpanel=(component "ivy-tab-panel" tabsContainer=this))}}
+{{yield (hash tablist=(component "ivy-tab-list" on-select=on-select tabsContainer=this) tabpanel=(component "ivy-tab-panel" tabsContainer=this))}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,4 +1,4 @@
-{{#ivy-tabs as |tabs|}}
+{{#ivy-tabs selected-index=selectedIndex update=(action (mut selectedIndex)) as |tabs|}}
   {{#tabs.tablist as |tablist|}}
     {{#tablist.tab}}Tab A{{/tablist.tab}}
     {{#tablist.tab}}Tab B{{/tablist.tab}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,4 +1,4 @@
-{{#ivy-tabs selected-index=selectedIndex update=(action (mut selectedIndex)) as |tabs|}}
+{{#ivy-tabs on-select=(action (mut selectedIndex)) selected-index=selectedIndex as |tabs|}}
   {{#tabs.tablist as |tablist|}}
     {{#tablist.tab}}Tab A{{/tablist.tab}}
     {{#tablist.tab}}Tab B{{/tablist.tab}}

--- a/tests/integration/components/ivy-tabs-test.js
+++ b/tests/integration/components/ivy-tabs-test.js
@@ -7,7 +7,7 @@ moduleForComponent('ivy-tabs', {
 });
 
 const basicTemplate = hbs`
-  {{#ivy-tabs selected-index=selectedIndex as |tabs|}}
+  {{#ivy-tabs selected-index=selectedIndex update=(action (mut selectedIndex)) as |tabs|}}
     {{#tabs.tablist id="tablist" as |tablist|}}
       {{#tablist.tab id="tab1"}}tab 1{{/tablist.tab}}
       {{#tablist.tab id="tab2"}}tab 2{{/tablist.tab}}
@@ -107,7 +107,7 @@ test('deselected panel attributes', function(assert) {
 });
 
 const eachTemplate = hbs`
-  {{#ivy-tabs selected-index=selectedIndex as |tabs|}}
+  {{#ivy-tabs selected-index=selectedIndex update=(action (mut selectedIndex)) as |tabs|}}
     {{#tabs.tablist as |tablist|}}
       {{#each items as |item|}}
         {{#tablist.tab}}{{item}}{{/tablist.tab}}

--- a/tests/integration/components/ivy-tabs-test.js
+++ b/tests/integration/components/ivy-tabs-test.js
@@ -7,7 +7,7 @@ moduleForComponent('ivy-tabs', {
 });
 
 const basicTemplate = hbs`
-  {{#ivy-tabs selected-index=selectedIndex update=(action (mut selectedIndex)) as |tabs|}}
+  {{#ivy-tabs on-select=(action (mut selectedIndex)) selected-index=selectedIndex as |tabs|}}
     {{#tabs.tablist id="tablist" as |tablist|}}
       {{#tablist.tab id="tab1"}}tab 1{{/tablist.tab}}
       {{#tablist.tab id="tab2"}}tab 2{{/tablist.tab}}
@@ -107,7 +107,7 @@ test('deselected panel attributes', function(assert) {
 });
 
 const eachTemplate = hbs`
-  {{#ivy-tabs selected-index=selectedIndex update=(action (mut selectedIndex)) as |tabs|}}
+  {{#ivy-tabs on-select=(action (mut selectedIndex)) selected-index=selectedIndex as |tabs|}}
     {{#tabs.tablist as |tablist|}}
       {{#each items as |item|}}
         {{#tablist.tab}}{{item}}{{/tablist.tab}}


### PR DESCRIPTION
This PR changes `selected-index` to a one-way binding, and adds an `on-select` action which is sent whenever a tab is selected. As an argument, the action receives the index of the newly-selected tab.