### PR TITLE
Adding option to remove inactive content.

### DIFF
--- a/addon/components/ivy-tab-panel.js
+++ b/addon/components/ivy-tab-panel.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import layout from '../templates/components/ivy-tab-panel';
 
 /**
  * @module ivy-tabs
@@ -10,6 +11,8 @@ import Ember from 'ember';
  * @extends Ember.Component
  */
 export default Ember.Component.extend({
+  layout: layout,
+
   attributeBindings: ['aria-hidden', 'aria-labelledby'],
   classNames: ['ivy-tab-panel'],
   classNameBindings: ['active'],

--- a/addon/components/ivy-tabs.js
+++ b/addon/components/ivy-tabs.js
@@ -16,6 +16,15 @@ export default Ember.Component.extend({
   classNames: ['ivy-tabs'],
 
   /**
+   * Set this to true if you'd like only the active tab panel to be rendered to the DOM.
+   *
+   * @property remove-inactive-content
+   * @type Boolean
+   * @default false
+   */
+  'remove-inactive-content': false,
+
+  /**
    * Set this to the index of the tab you'd like to be selected. Usually it is
    * bound to a controller property that is used as a query parameter, but can
    * be bound to anything.

--- a/addon/templates/components/ivy-tab-panel.hbs
+++ b/addon/templates/components/ivy-tab-panel.hbs
@@ -1,0 +1,7 @@
+{{#if remove-inactive-content}}
+  {{#if isSelected}}
+    {{yield}}
+  {{/if}}
+{{else}}
+  {{yield}}
+{{/if}}

--- a/addon/templates/components/ivy-tabs.hbs
+++ b/addon/templates/components/ivy-tabs.hbs
@@ -1,1 +1,1 @@
-{{yield (hash tablist=(component "ivy-tab-list" on-select=on-select tabsContainer=this) tabpanel=(component "ivy-tab-panel" tabsContainer=this))}}
+{{yield (hash tablist=(component "ivy-tab-list" on-select=on-select tabsContainer=this) tabpanel=(component "ivy-tab-panel" tabsContainer=this remove-inactive-content=remove-inactive-content))}}

--- a/tests/integration/components/ivy-tabs-test.js
+++ b/tests/integration/components/ivy-tabs-test.js
@@ -189,3 +189,24 @@ test('arrow keys navigate between tabs', function(assert) {
   assert.equal(this.get('selectedIndex'), 0, 'down arrow - tab1 is selected');
   assert.ok(tab1.get(0) === document.activeElement, 'tab1 has focus');
 });
+
+test('inactive tab content can be removed from the DOM', function(assert) {
+  this.render(hbs`
+    {{#ivy-tabs remove-inactive-content=true on-select=(action (mut selectedIndex)) selected-index=selectedIndex as |tabs|}}
+      {{#tabs.tablist id="tablist" as |tablist|}}
+        {{#tablist.tab id="tab1"}}tab 1{{/tablist.tab}}
+        {{#tablist.tab id="tab2"}}tab 2{{/tablist.tab}}
+      {{/tabs.tablist}}
+      {{#tabs.tabpanel id="panel1"}}panel 1{{/tabs.tabpanel}}
+      {{#tabs.tabpanel id="panel2"}}panel 2{{/tabs.tabpanel}}
+    {{/ivy-tabs}}
+  `);
+
+  assert.equal(this.$('#panel1').text().trim(), 'panel 1', 'panel1\'s content is in the DOM');
+  assert.equal(this.$('#panel2').text().trim(), '', 'panel2\'s content is not in the DOM');
+
+  this.$('#tab2').click();
+
+  assert.equal(this.$('#panel1').text().trim(), '', 'panel1\'s content is not in the DOM');
+  assert.equal(this.$('#panel2').text().trim(), 'panel 2', 'panel2\'s content is not in the DOM');
+});


### PR DESCRIPTION
Our team has some components that aren't rendered correctly if their containing elements are `display: none`. This PR adds an option so that only active content is rendered to the DOM. Fixes #17.