### PR TITLE
Select tabs by model

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ $ ember install ivy-tabs
 ### Templates
 
 ```handlebars
-{{#ivy-tabs selected=selectedTab as |tabs|}}
+{{#ivy-tabs selection=selection as |tabs|}}
   {{#tabs.tablist as |tablist|}}
-    {{#tablist.tab "TabA" on-select=(action (mut selectedTab))}}Foo{{/tablist.tab}}
-    {{#tablist.tab "TabB" on-select=(action (mut selectedTab))}}Bar{{/tablist.tab}}
-    {{#tablist.tab "TabC" on-select=(action (mut selectedTab))}}Baz{{/tablist.tab}}
+    {{#tablist.tab "TabA" on-select=(action (mut selection))}}Foo{{/tablist.tab}}
+    {{#tablist.tab "TabB" on-select=(action (mut selection))}}Bar{{/tablist.tab}}
+    {{#tablist.tab "TabC" on-select=(action (mut selection))}}Baz{{/tablist.tab}}
   {{/tabs.tablist}}
 
   {{#tabs.tabpanel "TabA"}}

--- a/README.md
+++ b/README.md
@@ -21,22 +21,22 @@ $ ember install ivy-tabs
 ### Templates
 
 ```handlebars
-{{#ivy-tabs on-select=(action (mut selectedIndex)) selected-index=selectedIndex as |tabs|}}
+{{#ivy-tabs selected=selectedTab as |tabs|}}
   {{#tabs.tablist as |tablist|}}
-    {{#tablist.tab}}Foo{{/tablist.tab}}
-    {{#tablist.tab}}Bar{{/tablist.tab}}
-    {{#tablist.tab}}Baz{{/tablist.tab}}
+    {{#tablist.tab "TabA" on-select=(action (mut selectedTab))}}Foo{{/tablist.tab}}
+    {{#tablist.tab "TabB" on-select=(action (mut selectedTab))}}Bar{{/tablist.tab}}
+    {{#tablist.tab "TabC" on-select=(action (mut selectedTab))}}Baz{{/tablist.tab}}
   {{/tabs.tablist}}
 
-  {{#tabs.tabpanel}}
+  {{#tabs.tabpanel "TabA"}}
     <h2>Foo</h2>
   {{/tabs.tabpanel}}
 
-  {{#tabs.tabpanel}}
+  {{#tabs.tabpanel "TabB"}}
     <h2>Bar</h2>
   {{/tabs.tabpanel}}
 
-  {{#tabs.tabpanel}}
+  {{#tabs.tabpanel "TabC"}}
     <h2>Baz</h2>
   {{/tabs.tabpanel}}
 {{/ivy-tabs}}
@@ -44,9 +44,13 @@ $ ember install ivy-tabs
 
 Some things to note:
 
-  * Associations between tabs and panels are inferred by order.
+  * Associations between tabs and panels are explicitly defined by the "models"
+    (the first positional parameter) given to them. In the above example, the
+    given tab models are "TabA", "TabB", and "TabC". This model could be any
+    JavaScript Object that you'd like, they are not required to be strings.
   * An `on-select` action is sent when a tab is selected. As an argument, it
-    receives the index (0-based) of the selected tab.
+    receives the model defined on the tab (for example, when the Foo tab is
+    selected, the `on-select` event will carry "TabA" as an argument).
 
 ### Presentation
 

--- a/addon/components/ivy-tab-list.js
+++ b/addon/components/ivy-tab-list.js
@@ -125,7 +125,7 @@ export default Ember.Component.extend({
     this.selectTabByIndex(index);
   },
 
-  selected: Ember.computed.alias('tabsContainer.selected'),
+  selection: Ember.computed.alias('tabsContainer.selection'),
 
   /**
    * The currently-selected `ivy-tab` instance.
@@ -133,8 +133,8 @@ export default Ember.Component.extend({
    * @property selectedTab
    * @type IvyTabs.IvyTabComponent
    */
-  selectedTab: Ember.computed('selected', 'tabs.@each.model', function() {
-    return this.get('tabs').findBy('model', this.get('selected'));
+  selectedTab: Ember.computed('selection', 'tabs.@each.model', function() {
+    return this.get('tabs').findBy('model', this.get('selection'));
   }),
 
   /**

--- a/addon/components/ivy-tab-list.js
+++ b/addon/components/ivy-tab-list.js
@@ -90,11 +90,10 @@ export default Ember.Component.extend({
    */
   registerTab(tab) {
     const tabs = this.get('tabs');
+    const tabsContainer = this.get('tabsContainer');
     tabs.pushObject(tab);
 
-    if (tabs.get('length') === 1) {
-      tab.select();
-    }
+    Ember.run.scheduleOnce('afterRender', tabsContainer, tabsContainer.selectTab);
   },
 
   /**

--- a/addon/components/ivy-tab-panel.js
+++ b/addon/components/ivy-tab-panel.js
@@ -99,14 +99,22 @@ export default Ember.Component.extend({
   isSelected: Ember.computed.readOnly('tab.isSelected'),
 
   /**
+   * Object to uniquely identify this tab within the tabList.
+   *
+   * @property model
+   * @type Object
+   */
+  model: null,
+
+  /**
    * The `ivy-tab` associated with this panel.
    *
    * @property tab
    * @type IvyTabs.IvyTabComponent
    */
-  tab: Ember.computed('tabs.[]', 'index', function() {
+  tab: Ember.computed('model', 'tabs.@each.model', function() {
     const tabs = this.get('tabs');
-    if (tabs) { return tabs.objectAt(this.get('index')); }
+    if (tabs) { return tabs.findBy('model', this.get('model')); }
   }),
 
   /**
@@ -153,4 +161,6 @@ export default Ember.Component.extend({
   _unregisterWithTabsContainer() {
     this.get('tabsContainer').unregisterTabPanel(this);
   }
+}).reopenClass({
+  positionalParams: ['model']
 });

--- a/addon/components/ivy-tab-panel.js
+++ b/addon/components/ivy-tab-panel.js
@@ -80,16 +80,6 @@ export default Ember.Component.extend({
   activeClass: 'active',
 
   /**
-   * The index of this panel in the `ivy-tabs` component.
-   *
-   * @property index
-   * @type Number
-   */
-  index: Ember.computed('tabPanels.[]', function() {
-    return this.get('tabPanels').indexOf(this);
-  }),
-
-  /**
    * Whether or not this panel's associated tab is selected.
    *
    * @property isSelected
@@ -118,32 +108,13 @@ export default Ember.Component.extend({
   }),
 
   /**
-   * The `ivy-tab-list` component this panel belongs to.
-   *
-   * @property tabList
-   * @type IvyTabs.IvyTabListComponent
-   * @readOnly
-   */
-  tabList: Ember.computed.readOnly('tabsContainer.tabList'),
-
-  /**
-   * The array of all `ivy-tab-panel` instances within the `ivy-tabs`
-   * component.
-   *
-   * @property tabPanels
-   * @type Array | IvyTabs.IvyTabPanelComponent
-   * @readOnly
-   */
-  tabPanels: Ember.computed.readOnly('tabsContainer.tabPanels'),
-
-  /**
    * The array of all `ivy-tab` instances within the `ivy-tab-list` component.
    *
    * @property tabs
    * @type Array | IvyTabs.IvyTabComponent
    * @readOnly
    */
-  tabs: Ember.computed.readOnly('tabList.tabs'),
+  tabs: Ember.computed.readOnly('tabsContainer.tabList.tabs'),
 
   /**
    * The `ivy-tabs` component.

--- a/addon/components/ivy-tab.js
+++ b/addon/components/ivy-tab.js
@@ -136,12 +136,20 @@ export default Ember.Component.extend({
   }),
 
   /**
+   * Object to uniquely identify this tab within the tabList.
+   *
+   * @property model
+   * @type Object
+   */
+  model: null,
+
+  /**
    * Called when the user clicks on the tab. Selects this tab.
    *
    * @method select
    */
   select: Ember.on('click', 'touchEnd', function() {
-    this.get('tabList').selectTab(this);
+    this.sendAction('on-select', this.get('model'));
   }),
 
   /**
@@ -159,8 +167,8 @@ export default Ember.Component.extend({
    * @property tabPanel
    * @type IvyTabs.IvyTabPanelComponent
    */
-  tabPanel: Ember.computed('tabPanels.[]', 'index', function() {
-    return this.get('tabPanels').objectAt(this.get('index'));
+  tabPanel: Ember.computed('tabPanels.@each.model', 'model', function() {
+    return this.get('tabPanels').findBy('model', this.get('model'));
   }),
 
   /**
@@ -198,4 +206,6 @@ export default Ember.Component.extend({
   _unregisterWithTabList() {
     this.get('tabList').unregisterTab(this);
   }
+}).reopenClass({
+  positionalParams: ['model']
 });

--- a/addon/components/ivy-tabs.js
+++ b/addon/components/ivy-tabs.js
@@ -20,10 +20,10 @@ export default Ember.Component.extend({
    * bound to a controller property that is used as a query parameter, but can
    * be bound to anything.
    *
-   * @property selected
+   * @property selection
    * @type Object
    */
-  selected: null,
+  selection: null,
 
   /**
    * Registers the `ivy-tab-list` instance.
@@ -47,11 +47,11 @@ export default Ember.Component.extend({
   },
 
   selectTab() {
-    let selected = this.get('selected');
-    if (Ember.isNone(selected)) {
+    let selection = this.get('selection');
+    if (Ember.isNone(selection)) {
       this.get('tabList').selectTabByIndex(0);
     } else {
-      this.get('tabList').selectTabByModel(selected);
+      this.get('tabList').selectTabByModel(selection);
     }
   },
 

--- a/addon/components/ivy-tabs.js
+++ b/addon/components/ivy-tabs.js
@@ -16,15 +16,14 @@ export default Ember.Component.extend({
   classNames: ['ivy-tabs'],
 
   /**
-   * Set this to the index of the tab you'd like to be selected. Usually it is
+   * Set this to the model of the tab you'd like to be selected. Usually it is
    * bound to a controller property that is used as a query parameter, but can
    * be bound to anything.
    *
-   * @property selected-index
-   * @type Number
-   * @default 0
+   * @property selected
+   * @type Object
    */
-  'selected-index': 0,
+  selected: null,
 
   /**
    * Registers the `ivy-tab-list` instance.
@@ -34,7 +33,7 @@ export default Ember.Component.extend({
    */
   registerTabList(tabList) {
     this.set('tabList', tabList);
-    Ember.run.once(this, this._selectTabByIndex);
+    Ember.run.once(this, this._selectTabByModel);
   },
 
   /**
@@ -71,9 +70,12 @@ export default Ember.Component.extend({
     this.get('tabPanels').removeObject(tabPanel);
   },
 
-  _selectTabByIndex() {
-    let selectedIndex = this.get('selected-index');
-    if (Ember.isNone(selectedIndex)) { selectedIndex = 0; }
-    this.get('tabList').selectTabByIndex(selectedIndex);
+  _selectTabByModel() {
+    let selected = this.get('selected');
+    if (Ember.isNone(selected)) {
+      this.get('tabList').selectTabByIndex(0);
+    } else {
+      this.get('tabList').selectTabByModel(selected);
+    }
   }
 });

--- a/addon/components/ivy-tabs.js
+++ b/addon/components/ivy-tabs.js
@@ -33,7 +33,7 @@ export default Ember.Component.extend({
    */
   registerTabList(tabList) {
     this.set('tabList', tabList);
-    Ember.run.once(this, this._selectTabByModel);
+    Ember.run.once(this, this.selectTab);
   },
 
   /**
@@ -44,6 +44,15 @@ export default Ember.Component.extend({
    */
   registerTabPanel(tabPanel) {
     this.get('tabPanels').pushObject(tabPanel);
+  },
+
+  selectTab() {
+    let selected = this.get('selected');
+    if (Ember.isNone(selected)) {
+      this.get('tabList').selectTabByIndex(0);
+    } else {
+      this.get('tabList').selectTabByModel(selected);
+    }
   },
 
   tabPanels: Ember.computed(function() {
@@ -68,14 +77,5 @@ export default Ember.Component.extend({
    */
   unregisterTabPanel(tabPanel) {
     this.get('tabPanels').removeObject(tabPanel);
-  },
-
-  _selectTabByModel() {
-    let selected = this.get('selected');
-    if (Ember.isNone(selected)) {
-      this.get('tabList').selectTabByIndex(0);
-    } else {
-      this.get('tabList').selectTabByModel(selected);
-    }
   }
 });

--- a/addon/templates/components/ivy-tabs.hbs
+++ b/addon/templates/components/ivy-tabs.hbs
@@ -1,1 +1,1 @@
-{{yield (hash tablist=(component "ivy-tab-list" on-select=on-select tabsContainer=this) tabpanel=(component "ivy-tab-panel" tabsContainer=this))}}
+{{yield (hash tablist=(component "ivy-tab-list" tabsContainer=this) tabpanel=(component "ivy-tab-panel" tabsContainer=this))}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,12 +1,12 @@
-{{#ivy-tabs on-select=(action (mut selectedIndex)) selected-index=selectedIndex as |tabs|}}
+{{#ivy-tabs selected=selected as |tabs|}}
   {{#tabs.tablist as |tablist|}}
-    {{#tablist.tab}}Tab A{{/tablist.tab}}
-    {{#tablist.tab}}Tab B{{/tablist.tab}}
-    {{#tablist.tab}}Tab C{{/tablist.tab}}
+    {{#tablist.tab "A" on-select=(action (mut selected))}}Tab A{{/tablist.tab}}
+    {{#tablist.tab "B" on-select=(action (mut selected))}}Tab B{{/tablist.tab}}
+    {{#tablist.tab "C" on-select=(action (mut selected))}}Tab C{{/tablist.tab}}
   {{/tabs.tablist}}
 
   <div class="tab-content">
-    {{#tabs.tabpanel}}
+    {{#tabs.tabpanel "A"}}
       <h2>Tab A</h2>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
@@ -19,7 +19,7 @@
       </p>
     {{/tabs.tabpanel}}
 
-    {{#tabs.tabpanel}}
+    {{#tabs.tabpanel "B"}}
       <h2>Tab B</h2>
       <p>
         Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -31,7 +31,7 @@
       </p>
     {{/tabs.tabpanel}}
 
-    {{#tabs.tabpanel}}
+    {{#tabs.tabpanel "C"}}
       <h2>Tab C</h2>
       <p>
         Veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,8 +1,8 @@
-{{#ivy-tabs selected=selected as |tabs|}}
+{{#ivy-tabs selection=selection as |tabs|}}
   {{#tabs.tablist as |tablist|}}
-    {{#tablist.tab "A" on-select=(action (mut selected))}}Tab A{{/tablist.tab}}
-    {{#tablist.tab "B" on-select=(action (mut selected))}}Tab B{{/tablist.tab}}
-    {{#tablist.tab "C" on-select=(action (mut selected))}}Tab C{{/tablist.tab}}
+    {{#tablist.tab "A" on-select=(action (mut selection))}}Tab A{{/tablist.tab}}
+    {{#tablist.tab "B" on-select=(action (mut selection))}}Tab B{{/tablist.tab}}
+    {{#tablist.tab "C" on-select=(action (mut selection))}}Tab C{{/tablist.tab}}
   {{/tabs.tablist}}
 
   <div class="tab-content">

--- a/tests/integration/components/ivy-tabs-test.js
+++ b/tests/integration/components/ivy-tabs-test.js
@@ -7,10 +7,10 @@ moduleForComponent('ivy-tabs', {
 });
 
 const basicTemplate = hbs`
-  {{#ivy-tabs selected=selectedModel as |tabs|}}
+  {{#ivy-tabs selection=selection as |tabs|}}
     {{#tabs.tablist id="tablist" as |tablist|}}
-      {{#tablist.tab "Item 1" id="tab1" on-select=(action (mut selectedModel))}}tab 1{{/tablist.tab}}
-      {{#tablist.tab "Item 2" id="tab2" on-select=(action (mut selectedModel))}}tab 2{{/tablist.tab}}
+      {{#tablist.tab "Item 1" id="tab1" on-select=(action (mut selection))}}tab 1{{/tablist.tab}}
+      {{#tablist.tab "Item 2" id="tab2" on-select=(action (mut selection))}}tab 2{{/tablist.tab}}
     {{/tabs.tablist}}
     {{#tabs.tabpanel "Item 1" id="panel1"}}panel 1{{/tabs.tabpanel}}
     {{#tabs.tabpanel "Item 2" id="panel2"}}panel 2{{/tabs.tabpanel}}
@@ -20,28 +20,28 @@ const basicTemplate = hbs`
 test('selects first tab by default', function(assert) {
   this.render(basicTemplate);
 
-  assert.equal(this.get('selectedModel'), 'Item 1', 'selected');
+  assert.equal(this.get('selection'), 'Item 1', 'selection');
 });
 
 test('selects tab by model', function(assert) {
-  this.set('selectedModel', 'Item 2');
+  this.set('selection', 'Item 2');
   this.render(basicTemplate);
 
-  assert.equal(this.get('selectedModel'), 'Item 2', 'selected');
+  assert.equal(this.get('selection'), 'Item 2', 'selection');
 });
 
 test('selects tab on click', function(assert) {
   this.render(basicTemplate);
   this.$('#tab2').click();
 
-  assert.equal(this.get('selectedModel'), 'Item 2', 'selected-index');
+  assert.equal(this.get('selection'), 'Item 2', 'selection');
 });
 
 test('selects tab on touchEnd', function(assert) {
   this.render(basicTemplate);
   this.$('#tab2').trigger('touchend');
 
-  assert.equal(this.get('selectedModel'), 'Item 2', 'selected-index');
+  assert.equal(this.get('selection'), 'Item 2', 'selection');
 });
 
 test('WAI-ARIA attributes', function(assert) {
@@ -105,10 +105,10 @@ test('deselected panel attributes', function(assert) {
 });
 
 const eachTemplate = hbs`
-  {{#ivy-tabs selected=selectedModel as |tabs|}}
+  {{#ivy-tabs selection=selection as |tabs|}}
     {{#tabs.tablist as |tablist|}}
       {{#each items as |item|}}
-        {{#tablist.tab item on-select=(action (mut selectedModel))}}{{item}}{{/tablist.tab}}
+        {{#tablist.tab item on-select=(action (mut selection))}}{{item}}{{/tablist.tab}}
       {{/each}}
     {{/tabs.tablist}}
     {{#each items as |item|}}
@@ -118,7 +118,7 @@ const eachTemplate = hbs`
 `;
 
 test('selects previous tab if active tab is removed', function(assert) {
-  this.set('selectedModel', 'Item 1');
+  this.set('selection', 'Item 1');
   this.set('items', Ember.A(['Item 1', 'Item 2']));
   this.render(eachTemplate);
 
@@ -126,11 +126,11 @@ test('selects previous tab if active tab is removed', function(assert) {
     this.get('items').removeAt(1);
   });
 
-  assert.equal(this.get('selectedModel'), 'Item 1', 'previous tab became active');
+  assert.equal(this.get('selection'), 'Item 1', 'previous tab became active');
 });
 
 test('selects previous tab if active tab is removed via replacement', function(assert) {
-  this.set('selectedModel', 'Item 2');
+  this.set('selection', 'Item 2');
   this.set('items', Ember.A(['Item 1', 'Item 2']));
   this.render(eachTemplate);
 
@@ -138,11 +138,11 @@ test('selects previous tab if active tab is removed via replacement', function(a
     this.set('items', Ember.A(['Item 3']));
   });
 
-  assert.equal(this.get('selectedModel'), 'Item 3', 'previous tab became active');
+  assert.equal(this.get('selection'), 'Item 3', 'previous tab became active');
 });
 
 test('retains tab selection if preceeding tab is removed', function(assert) {
-  this.set('selectedModel', 'Item 2');
+  this.set('selection', 'Item 2');
   this.set('items', Ember.A(['Item 1', 'Item 2']));
   this.render(eachTemplate);
 
@@ -150,11 +150,11 @@ test('retains tab selection if preceeding tab is removed', function(assert) {
     this.get('items').removeAt(0);
   });
 
-  assert.equal(this.get('selectedModel'), 'Item 2', 'tab selection is retained');
+  assert.equal(this.get('selection'), 'Item 2', 'tab selection is retained');
 });
 
 test('selects the next tab when an active, first tab is removed', function(assert) {
-  this.set('selectedModel', 'Item 1');
+  this.set('selection', 'Item 1');
   this.set('items', Ember.A(['Item 1', 'Item 2', 'Item 3']));
   this.render(eachTemplate);
 
@@ -162,7 +162,7 @@ test('selects the next tab when an active, first tab is removed', function(asser
     this.get('items').removeAt(0);
   });
 
-  assert.equal(this.get('selectedModel'), 'Item 2', 'selects next tab');
+  assert.equal(this.get('selection'), 'Item 2', 'selects next tab');
 });
 
 test('arrow keys navigate between tabs', function(assert) {
@@ -172,18 +172,18 @@ test('arrow keys navigate between tabs', function(assert) {
   const tab2 = this.$('#tab2');
 
   Ember.run(tab1, 'trigger', Ember.$.Event('keydown', { keyCode: 37 }));
-  assert.equal(this.get('selectedModel'), 'Item 2', 'left arrow - tab2 is selected');
+  assert.equal(this.get('selection'), 'Item 2', 'left arrow - tab2 is selected');
   assert.ok(tab2.get(0) === document.activeElement, 'tab2 has focus');
 
   Ember.run(tab2, 'trigger', Ember.$.Event('keydown', { keyCode: 38 }));
-  assert.equal(this.get('selectedModel'), 'Item 1', 'up arrow - tab1 is selected');
+  assert.equal(this.get('selection'), 'Item 1', 'up arrow - tab1 is selected');
   assert.ok(tab1.get(0) === document.activeElement, 'tab1 has focus');
 
   Ember.run(tab1, 'trigger', Ember.$.Event('keydown', { keyCode: 39 }));
-  assert.equal(this.get('selectedModel'), 'Item 2', 'right arrow - tab2 is selected');
+  assert.equal(this.get('selection'), 'Item 2', 'right arrow - tab2 is selected');
   assert.ok(tab2.get(0) === document.activeElement, 'tab2 has focus');
 
   Ember.run(tab2, 'trigger', Ember.$.Event('keydown', { keyCode: 40 }));
-  assert.equal(this.get('selectedModel'), 'Item 1', 'down arrow - tab1 is selected');
+  assert.equal(this.get('selection'), 'Item 1', 'down arrow - tab1 is selected');
   assert.ok(tab1.get(0) === document.activeElement, 'tab1 has focus');
 });

--- a/tests/integration/components/ivy-tabs-test.js
+++ b/tests/integration/components/ivy-tabs-test.js
@@ -7,41 +7,41 @@ moduleForComponent('ivy-tabs', {
 });
 
 const basicTemplate = hbs`
-  {{#ivy-tabs on-select=(action (mut selectedIndex)) selected-index=selectedIndex as |tabs|}}
+  {{#ivy-tabs selected=selectedModel as |tabs|}}
     {{#tabs.tablist id="tablist" as |tablist|}}
-      {{#tablist.tab id="tab1"}}tab 1{{/tablist.tab}}
-      {{#tablist.tab id="tab2"}}tab 2{{/tablist.tab}}
+      {{#tablist.tab "Item 1" id="tab1" on-select=(action (mut selectedModel))}}tab 1{{/tablist.tab}}
+      {{#tablist.tab "Item 2" id="tab2" on-select=(action (mut selectedModel))}}tab 2{{/tablist.tab}}
     {{/tabs.tablist}}
-    {{#tabs.tabpanel id="panel1"}}panel 1{{/tabs.tabpanel}}
-    {{#tabs.tabpanel id="panel2"}}panel 2{{/tabs.tabpanel}}
+    {{#tabs.tabpanel "Item 1" id="panel1"}}panel 1{{/tabs.tabpanel}}
+    {{#tabs.tabpanel "Item 2" id="panel2"}}panel 2{{/tabs.tabpanel}}
   {{/ivy-tabs}}
 `;
 
 test('selects first tab by default', function(assert) {
   this.render(basicTemplate);
 
-  assert.equal(this.get('selectedIndex'), 0, 'selected-index');
+  assert.equal(this.get('selectedModel'), 'Item 1', 'selected');
 });
 
-test('selects tab by index', function(assert) {
-  this.set('selectedIndex', 1);
+test('selects tab by model', function(assert) {
+  this.set('selectedModel', 'Item 2');
   this.render(basicTemplate);
 
-  assert.equal(this.get('selectedIndex'), 1, 'selected-index');
+  assert.equal(this.get('selectedModel'), 'Item 2', 'selected');
 });
 
 test('selects tab on click', function(assert) {
   this.render(basicTemplate);
   this.$('#tab2').click();
 
-  assert.equal(this.get('selectedIndex'), 1, 'selected-index');
+  assert.equal(this.get('selectedModel'), 'Item 2', 'selected-index');
 });
 
 test('selects tab on touchEnd', function(assert) {
   this.render(basicTemplate);
   this.$('#tab2').trigger('touchend');
 
-  assert.equal(this.get('selectedIndex'), 1, 'selected-index');
+  assert.equal(this.get('selectedModel'), 'Item 2', 'selected-index');
 });
 
 test('WAI-ARIA attributes', function(assert) {
@@ -105,20 +105,20 @@ test('deselected panel attributes', function(assert) {
 });
 
 const eachTemplate = hbs`
-  {{#ivy-tabs on-select=(action (mut selectedIndex)) selected-index=selectedIndex as |tabs|}}
+  {{#ivy-tabs selected=selectedModel as |tabs|}}
     {{#tabs.tablist as |tablist|}}
       {{#each items as |item|}}
-        {{#tablist.tab}}{{item}}{{/tablist.tab}}
+        {{#tablist.tab item on-select=(action (mut selectedModel))}}{{item}}{{/tablist.tab}}
       {{/each}}
     {{/tabs.tablist}}
     {{#each items as |item|}}
-      {{#tabs.tabpanel}}{{item}}{{/tabs.tabpanel}}
+      {{#tabs.tabpanel item}}{{item}}{{/tabs.tabpanel}}
     {{/each}}
   {{/ivy-tabs}}
 `;
 
 test('selects previous tab if active tab is removed', function(assert) {
-  this.set('selectedIndex', 1);
+  this.set('selectedModel', 'Item 1');
   this.set('items', Ember.A(['Item 1', 'Item 2']));
   this.render(eachTemplate);
 
@@ -126,11 +126,11 @@ test('selects previous tab if active tab is removed', function(assert) {
     this.get('items').removeAt(1);
   });
 
-  assert.equal(this.get('selectedIndex'), 0, 'previous tab became active');
+  assert.equal(this.get('selectedModel'), 'Item 1', 'previous tab became active');
 });
 
 test('selects previous tab if active tab is removed via replacement', function(assert) {
-  this.set('selectedIndex', 1);
+  this.set('selectedModel', 'Item 2');
   this.set('items', Ember.A(['Item 1', 'Item 2']));
   this.render(eachTemplate);
 
@@ -138,11 +138,11 @@ test('selects previous tab if active tab is removed via replacement', function(a
     this.set('items', Ember.A(['Item 3']));
   });
 
-  assert.equal(this.get('selectedIndex'), 0, 'previous tab became active');
+  assert.equal(this.get('selectedModel'), 'Item 3', 'previous tab became active');
 });
 
 test('retains tab selection if preceeding tab is removed', function(assert) {
-  this.set('selectedIndex', 1);
+  this.set('selectedModel', 'Item 2');
   this.set('items', Ember.A(['Item 1', 'Item 2']));
   this.render(eachTemplate);
 
@@ -150,11 +150,11 @@ test('retains tab selection if preceeding tab is removed', function(assert) {
     this.get('items').removeAt(0);
   });
 
-  assert.equal(this.get('selectedIndex'), 0, 'tab selection is retained');
+  assert.equal(this.get('selectedModel'), 'Item 2', 'tab selection is retained');
 });
 
 test('selects the next tab when an active, first tab is removed', function(assert) {
-  this.set('selectedIndex', 0);
+  this.set('selectedModel', 'Item 1');
   this.set('items', Ember.A(['Item 1', 'Item 2', 'Item 3']));
   this.render(eachTemplate);
 
@@ -162,7 +162,7 @@ test('selects the next tab when an active, first tab is removed', function(asser
     this.get('items').removeAt(0);
   });
 
-  assert.equal(this.get('selectedIndex'), 0, 'selects next tab');
+  assert.equal(this.get('selectedModel'), 'Item 2', 'selects next tab');
 });
 
 test('arrow keys navigate between tabs', function(assert) {
@@ -172,18 +172,18 @@ test('arrow keys navigate between tabs', function(assert) {
   const tab2 = this.$('#tab2');
 
   Ember.run(tab1, 'trigger', Ember.$.Event('keydown', { keyCode: 37 }));
-  assert.equal(this.get('selectedIndex'), 1, 'left arrow - tab2 is selected');
+  assert.equal(this.get('selectedModel'), 'Item 2', 'left arrow - tab2 is selected');
   assert.ok(tab2.get(0) === document.activeElement, 'tab2 has focus');
 
   Ember.run(tab2, 'trigger', Ember.$.Event('keydown', { keyCode: 38 }));
-  assert.equal(this.get('selectedIndex'), 0, 'up arrow - tab1 is selected');
+  assert.equal(this.get('selectedModel'), 'Item 1', 'up arrow - tab1 is selected');
   assert.ok(tab1.get(0) === document.activeElement, 'tab1 has focus');
 
   Ember.run(tab1, 'trigger', Ember.$.Event('keydown', { keyCode: 39 }));
-  assert.equal(this.get('selectedIndex'), 1, 'right arrow - tab2 is selected');
+  assert.equal(this.get('selectedModel'), 'Item 2', 'right arrow - tab2 is selected');
   assert.ok(tab2.get(0) === document.activeElement, 'tab2 has focus');
 
   Ember.run(tab2, 'trigger', Ember.$.Event('keydown', { keyCode: 40 }));
-  assert.equal(this.get('selectedIndex'), 0, 'down arrow - tab1 is selected');
+  assert.equal(this.get('selectedModel'), 'Item 1', 'down arrow - tab1 is selected');
   assert.ok(tab1.get(0) === document.activeElement, 'tab1 has focus');
 });


### PR DESCRIPTION
Rather than dealing with indices, it is more powerful to have "models" associated with tabs and tab panels.

The biggest win is that actions getting emitted when a tab is selected will now carry application-specific meaning rather than arbitrary indices/numbers.

Using models rather than indices also _potentially_ allows for tabs and tab panels to be defined in differing orders, but this is really just a side-effect.

💥  This is definitely a breaking change.