### PR TITLE
Remove ivy-tab-panel isVisible manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ $ ember install ivy-tabs
 
 ## Usage
 
+### Templates
+
 ```handlebars
 {{#ivy-tabs on-select=(action (mut selectedIndex)) selected-index=selectedIndex as |tabs|}}
   {{#tabs.tablist as |tablist|}}
@@ -45,6 +47,39 @@ Some things to note:
   * Associations between tabs and panels are inferred by order.
   * An `on-select` action is sent when a tab is selected. As an argument, it
     receives the index (0-based) of the selected tab.
+
+### Presentation
+
+ivy-tabs does not make any assumptions about how you will present your tabs.
+Specifically, this means that ivy-tabs will not automatically hide unselected
+tab panels. Rather, you should update your application styles to reflect your
+needs.
+
+In an ideal world, your application would carry a CSS rule similar to the
+following:
+
+```css
+[aria-hidden="true"] {
+  display: none;
+}
+```
+
+If, for some reason, your target audience does not support CSS attribute
+selectors, you may also opt to instead rely on the ivy-tabs classes by
+defaulting all panels to being hidden and only displaying the active panel
+using CSS rules similar to (remember, `.active` will be different if you
+override the `activeClass` property of your ivy-tab-panel):
+
+```css
+.ivy-tab-panel {
+  display: none;
+}
+
+.ivy-tab-panel.active {
+  display: block;
+}
+```
+
 
 ## Contributing
 

--- a/addon/components/ivy-tab-panel.js
+++ b/addon/components/ivy-tab-panel.js
@@ -99,15 +99,6 @@ export default Ember.Component.extend({
   isSelected: Ember.computed.readOnly('tab.isSelected'),
 
   /**
-   * If `false`, this panel will appear hidden in the DOM. This is an alias to
-   * `isSelected`.
-   *
-   * @property isVisible
-   * @type Boolean
-   */
-  isVisible: Ember.computed.oneWay('isSelected'),
-
-  /**
    * The `ivy-tab` associated with this panel.
    *
    * @property tab

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,3 @@
+[aria-hidden="true"] {
+  display: none;
+}

--- a/tests/integration/components/ivy-tabs-test.js
+++ b/tests/integration/components/ivy-tabs-test.js
@@ -83,7 +83,6 @@ test('selected panel attributes', function(assert) {
   const panel = this.$('#panel1');
   assert.ok(panel.hasClass('active'), 'has "active" class');
   assert.equal(panel.attr('aria-hidden'), 'false', 'aria-hidden');
-  assert.ok(panel.is(':visible'), 'is visible');
 });
 
 test('deselected tab attributes', function(assert) {
@@ -103,7 +102,6 @@ test('deselected panel attributes', function(assert) {
   const panel = this.$('#panel2');
   assert.ok(!panel.hasClass('active'), 'does not have "active" class');
   assert.equal(panel.attr('aria-hidden'), 'true', 'aria-hidden');
-  assert.ok(!panel.is(':visible'), 'is not visible');
 });
 
 const eachTemplate = hbs`
@@ -188,32 +186,4 @@ test('arrow keys navigate between tabs', function(assert) {
   Ember.run(tab2, 'trigger', Ember.$.Event('keydown', { keyCode: 40 }));
   assert.equal(this.get('selectedIndex'), 0, 'down arrow - tab1 is selected');
   assert.ok(tab1.get(0) === document.activeElement, 'tab1 has focus');
-});
-
-test('allows isVisible to be set on panels', function(assert) {
-  const isVisibleTemplate = hbs`
-    {{#ivy-tabs on-select=(action (mut selectedIndex)) selected-index=selectedIndex as |tabs|}}
-      {{#tabs.tablist id="tablist" as |tablist|}}
-        {{#tablist.tab id="tab1"}}tab 1{{/tablist.tab}}
-        {{#tablist.tab id="tab2"}}tab 2{{/tablist.tab}}
-      {{/tabs.tablist}}
-      {{#tabs.tabpanel id="panel1" isVisible=true}}panel 1{{/tabs.tabpanel}}
-      {{#tabs.tabpanel id="panel2" isVisible=true}}panel 2{{/tabs.tabpanel}}
-    {{/ivy-tabs}}
-  `;
-  this.render(isVisibleTemplate);
-
-  const panel1 = this.$('#panel1');
-  const panel2 = this.$('#panel2');
-
-  assert.ok(panel1.is(':visible'), 'is visible');
-  assert.ok(panel2.is(':visible'), 'is visible');
-
-  this.$('#tab1').click();
-  assert.ok(panel1.is(':visible'), 'is visible');
-  assert.ok(panel2.is(':visible'), 'is visible');
-
-  this.$('#tab2').click();
-  assert.ok(panel1.is(':visible'), 'is visible');
-  assert.ok(panel2.is(':visible'), 'is visible');
 });


### PR DESCRIPTION
The idea here is to remove the assumption from the addon that developers will always want to explicitly hide tab panels in their application. In practice, we've found this to be an invalid assumption.

One counter use case identified is that it hinders the use of CSS animations on those tab panels, as you cannot animate hidden elements.

💥  This is a breaking change from the 2.x branch.