### PR TITLE
Rename components

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ using CSS rules similar to (remember, `.active` will be different if you
 override the `activeClass` property of your ivy-tabs-tabpanel):
 
 ```css
-.ivy-tab-panel {
+.ivy-tabs-tabpanel {
   display: none;
 }
 
-.ivy-tab-panel.active {
+.ivy-tabs-tabpanel.active {
   display: block;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If, for some reason, your target audience does not support CSS attribute
 selectors, you may also opt to instead rely on the ivy-tabs classes by
 defaulting all panels to being hidden and only displaying the active panel
 using CSS rules similar to (remember, `.active` will be different if you
-override the `activeClass` property of your ivy-tab-panel):
+override the `activeClass` property of your ivy-tabs-tabpanel):
 
 ```css
 .ivy-tab-panel {

--- a/addon/components/ivy-tabs-tab.js
+++ b/addon/components/ivy-tabs-tab.js
@@ -124,7 +124,7 @@ export default Ember.Component.extend({
   }).readOnly(),
 
   /**
-   * The index of this tab in the `ivy-tab-list` component.
+   * The index of this tab in the `ivy-tabs-tablist` component.
    *
    * @property index
    * @type Number
@@ -166,7 +166,7 @@ export default Ember.Component.extend({
   }),
 
   /**
-   * The `ivy-tab-list` component this tab belongs to.
+   * The `ivy-tabs-tablist` component this tab belongs to.
    *
    * @property tabList
    * @type IvyTabs.IvyTabListComponent
@@ -175,7 +175,7 @@ export default Ember.Component.extend({
   tabList: null,
 
   /**
-   * The `ivy-tab-panel` associated with this tab.
+   * The `ivy-tabs-tabpanel` associated with this tab.
    *
    * @property tabPanel
    * @type IvyTabs.IvyTabPanelComponent
@@ -185,7 +185,7 @@ export default Ember.Component.extend({
   }),
 
   /**
-   * The array of all `ivy-tab-panel` instances within the `ivy-tabs`
+   * The array of all `ivy-tabs-tabpanel` instances within the `ivy-tabs`
    * component.
    *
    * @property tabPanels
@@ -195,7 +195,7 @@ export default Ember.Component.extend({
   tabPanels: Ember.computed.readOnly('tabsContainer.tabPanels'),
 
   /**
-   * The array of all `ivy-tab` instances within the `ivy-tab-list` component.
+   * The array of all `ivy-tabs-tab` instances within the `ivy-tabs-tablist` component.
    *
    * @property tabs
    * @type Array | IvyTabs.IvyTabComponent

--- a/addon/components/ivy-tabs-tab.js
+++ b/addon/components/ivy-tabs-tab.js
@@ -12,7 +12,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   tagName: 'a',
   attributeBindings: ['aria-controls', 'aria-expanded', 'aria-selected', 'href', 'selected', 'tabindex'],
-  classNames: ['ivy-tab'],
+  classNames: ['ivy-tabs-tab'],
   classNameBindings: ['active'],
 
   init() {

--- a/addon/components/ivy-tabs-tablist.js
+++ b/addon/components/ivy-tabs-tablist.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import layout from '../templates/components/ivy-tab-list';
+import layout from '../templates/components/ivy-tabs-tablist';
 
 /**
  * @module ivy-tabs
@@ -127,7 +127,7 @@ export default Ember.Component.extend({
   selection: Ember.computed.alias('tabsContainer.selection'),
 
   /**
-   * The currently-selected `ivy-tab` instance.
+   * The currently-selected `ivy-tabs-tab` instance.
    *
    * @property selectedTab
    * @type IvyTabs.IvyTabComponent

--- a/addon/components/ivy-tabs-tablist.js
+++ b/addon/components/ivy-tabs-tablist.js
@@ -14,7 +14,7 @@ export default Ember.Component.extend({
   layout: layout,
 
   attributeBindings: ['aria-multiselectable'],
-  classNames: ['ivy-tab-list'],
+  classNames: ['ivy-tabs-tablist'],
 
   init() {
     this._super(...arguments);

--- a/addon/components/ivy-tabs-tabpanel.js
+++ b/addon/components/ivy-tabs-tabpanel.js
@@ -97,7 +97,7 @@ export default Ember.Component.extend({
   model: null,
 
   /**
-   * The `ivy-tab` associated with this panel.
+   * The `ivy-tabs-tab` associated with this panel.
    *
    * @property tab
    * @type IvyTabs.IvyTabComponent
@@ -108,7 +108,7 @@ export default Ember.Component.extend({
   }),
 
   /**
-   * The array of all `ivy-tab` instances within the `ivy-tab-list` component.
+   * The array of all `ivy-tabs-tab` instances within the `ivy-tabs-tablist` component.
    *
    * @property tabs
    * @type Array | IvyTabs.IvyTabComponent

--- a/addon/components/ivy-tabs-tabpanel.js
+++ b/addon/components/ivy-tabs-tabpanel.js
@@ -11,7 +11,7 @@ import Ember from 'ember';
  */
 export default Ember.Component.extend({
   attributeBindings: ['aria-hidden', 'aria-labelledby'],
-  classNames: ['ivy-tab-panel'],
+  classNames: ['ivy-tabs-tabpanel'],
   classNameBindings: ['active'],
 
   init() {

--- a/addon/components/ivy-tabs.js
+++ b/addon/components/ivy-tabs.js
@@ -26,7 +26,7 @@ export default Ember.Component.extend({
   selection: null,
 
   /**
-   * Registers the `ivy-tab-list` instance.
+   * Registers the `ivy-tabs-tablist` instance.
    *
    * @method registerTabList
    * @param {IvyTabs.IvyTabListComponent} tabList
@@ -60,7 +60,7 @@ export default Ember.Component.extend({
   }).readOnly(),
 
   /**
-   * Removes the `ivy-tab-list` component.
+   * Removes the `ivy-tabs-tablist` component.
    *
    * @method unregisterTabList
    * @param {IvyTabs.IvyTabListComponent} tabList

--- a/addon/templates/components/ivy-tab-list.hbs
+++ b/addon/templates/components/ivy-tab-list.hbs
@@ -1,1 +1,0 @@
-{{yield (hash tab=(component "ivy-tab" tabList=this))}}

--- a/addon/templates/components/ivy-tabs-tablist.hbs
+++ b/addon/templates/components/ivy-tabs-tablist.hbs
@@ -1,0 +1,1 @@
+{{yield (hash tab=(component "ivy-tabs-tab" tabList=this))}}

--- a/addon/templates/components/ivy-tabs.hbs
+++ b/addon/templates/components/ivy-tabs.hbs
@@ -1,1 +1,1 @@
-{{yield (hash tablist=(component "ivy-tab-list" tabsContainer=this) tabpanel=(component "ivy-tab-panel" tabsContainer=this))}}
+{{yield (hash tablist=(component "ivy-tabs-tablist" tabsContainer=this) tabpanel=(component "ivy-tabs-tabpanel" tabsContainer=this))}}

--- a/app/components/ivy-tab-list.js
+++ b/app/components/ivy-tab-list.js
@@ -1,1 +1,0 @@
-export { default } from 'ivy-tabs/components/ivy-tab-list';

--- a/app/components/ivy-tab-panel.js
+++ b/app/components/ivy-tab-panel.js
@@ -1,1 +1,0 @@
-export { default } from 'ivy-tabs/components/ivy-tab-panel';

--- a/app/components/ivy-tab.js
+++ b/app/components/ivy-tab.js
@@ -1,1 +1,0 @@
-export { default } from 'ivy-tabs/components/ivy-tab';

--- a/app/components/ivy-tabs-tab.js
+++ b/app/components/ivy-tabs-tab.js
@@ -1,0 +1,1 @@
+export { default } from 'ivy-tabs/components/ivy-tabs-tab';

--- a/app/components/ivy-tabs-tablist.js
+++ b/app/components/ivy-tabs-tablist.js
@@ -1,0 +1,1 @@
+export { default } from 'ivy-tabs/components/ivy-tabs-tablist';

--- a/app/components/ivy-tabs-tabpanel.js
+++ b/app/components/ivy-tabs-tabpanel.js
@@ -1,0 +1,1 @@
+export { default } from 'ivy-tabs/components/ivy-tabs-tabpanel';


### PR DESCRIPTION
This PR renames the components to namespace them under "ivy-tabs". It also changes their names to more closely mirror their ARIA role. So:

* `ivy-tab` becomes `ivy-tabs-tab`
* `ivy-tab-list` becomes `ivy-tabs-tablist`
* `ivy-tab-panel` becomes `ivy-tabs-tabpanel`

The corresponding CSS classes are also renamed to reflect these changes, so if you were previously relying on these in your stylesheet, you will need to change their names there as well.