### PR TITLE
Adding hint to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ $ ember install ivy-tabs
 {{/ivy-tabs}}
 ```
 
-Some things to note:
+## Hints
+
+### General
 
   * Associations between tabs and panels are explicitly defined by the "models"
     (the first positional parameter) given to them. In the above example, the
@@ -59,6 +61,47 @@ Some things to note:
   * An `on-select` action is sent when a tab is selected. As an argument, it
     receives the model defined on the tab (for example, when the Foo tab is
     selected, the `on-select` event will carry "TabA" as an argument).
+
+### Using an attribute of an `ember-data model` as `ivy-tab model`
+
+If you are going to use an attribute of an **ember-data model** as model of your tab, be sure you preload
+the values before using them in the template.
+
+If you don't preload the values, you are going to have problems when setting the `selection` option, because the tab models are going to be `undefined` when the addon tries to select the tab, causing an error.
+
+You can do that be loading the values in your route:
+
+```js
+...
+
+  afterModel(model) {
+    return Ember.RSVP.resolve(model.get('<the-models-you-need-to-set-the-ivy-tabs models>'));
+  },
+
+...
+
+```
+
+Doing this you are not going to have any problem using options like `selection`
+
+```js
+...
+
+  {{#ivy-tabs selection=selection as |tabs|}}
+    {{#tabs.tablist as |tablist|}}
+      <ul role="presentation">
+        {{#each <models-you-preload> as |<preloaded-model>| }}
+          <li>
+            {{#tablist.tab <preloaded-model>.<attr-to-be-used-as-tab-model> on-select=(action (mut selection)) }}
+              {{<preloaded-model>.<attr-to-be-used-as-tab-model>}}
+            {{/tablist.tab}}
+          </li>
+        {{/each}}
+      </ul>
+    {{/tabs.tablist}}
+
+...
+```
 
 ### Presentation
 


### PR DESCRIPTION
Hi,

I just noticed that if you use an attribute of an ember data model as model for ivy-tabs, it is needed to preload the models to avoid an error when using the `selection` option (for example).

I guess it happens because of the async request to fetch the models and their attributes it not fulfilled before you executed this method:

``` js
selectTabByModel(model) {
    const tab = this.get('tabs').findBy('model', model);

    if (!tab) {
      throw new Error('Tab could not be found by model');
    }

    tab.select();
  },

```

I assume it is responsibility of the developer to preload the information to be used to print the tabs. So, I added a section of the README to indicate it is important when using `selection` option.

**NOTE:** I tried to fix the problem from the addon, but it was getting this **WARNING** all the time:

```
DEPRECATION: You modified href twice in a single render. This was unreliable in Ember 1.x and will be removed in Ember 3.0 [deprecation id: ember-views.render-double-modify]
        at HANDLERS.(anonymous function) (http://localhost:4200/assets/vendor.js:16975:7)
        at raiseOnDeprecation (http://localhost:4200/assets/vendor.js:16883:12)
        at HANDLERS.(anonymous function) (http://localhost:4200/assets/vendor.js:16975:7)
        at invoke (http://localhost:4200/assets/vendor.js:16991:7)
        at deprecate (http://localhost:4200/assets/vendor.js:16944:32)
        at Object.deprecate (http://localhost:4200/assets/vendor.js:26983:37)
        at Class.exports.default._emberMetalMixin.Mixin.create._Mixin$create.scheduleRevalidate (http://localhost:4200/assets/vendor.js:54234:26)
        at http://localhost:4200/assets/vendor.js:24496:32
        at Object.notifySubscribers (http://localhost:4200/assets/vendor.js:32891:11)

```

Best regards,
Daniel
