### PR TITLE
Remove jquery usage from addon

### DIFF
--- a/addon/components/ivy-tabs-tablist.js
+++ b/addon/components/ivy-tabs-tablist.js
@@ -57,7 +57,8 @@ export default Component.extend({
    * @method focusSelectedTab
    */
   focusSelectedTab() {
-    this.get('selectedTab').$().focus();
+    console.log('focus');
+    this.get('selectedTab').element.focus();
   },
 
   /**

--- a/addon/components/ivy-tabs-tablist.js
+++ b/addon/components/ivy-tabs-tablist.js
@@ -57,7 +57,6 @@ export default Component.extend({
    * @method focusSelectedTab
    */
   focusSelectedTab() {
-    console.log('focus');
     this.get('selectedTab').element.focus();
   },
 


### PR DESCRIPTION
Currently, jQuery usage is minimal and removing it is trivial. This
change allows this addon to be consumed in a stack that has removed
jQuery.